### PR TITLE
add icon canhover

### DIFF
--- a/packages/ui/components/icon/Icon.vue
+++ b/packages/ui/components/icon/Icon.vue
@@ -7,9 +7,12 @@ import { useColor } from '@vuejs-jp/composable'
 export type IconProps = {
   color: Color
   name: IconName
+  canHover: boolean
 }
 
-const props = defineProps<IconProps>()
+const props = withDefaults(defineProps<IconProps>(),{
+  canHover: true
+})
 
 const svgComponent =
   match<IconName>(props.name)
@@ -34,11 +37,12 @@ const { color: fillColor } = useColor()
   <component
     :is="svgComponent"
     :fill="fillColor(props.color)"
+    :class="{'icon_svg' : props.canHover}"
   />
 </template>
 
 <style scoped>
-svg:hover {
+.icon_svg:hover {
   fill: #42b883;
   transition: .2s;
 }

--- a/packages/ui/components/link/LinkButton.vue
+++ b/packages/ui/components/link/LinkButton.vue
@@ -63,6 +63,7 @@ const iconColor = computed(() =>{
       v-if="props.iconName"
       :color="iconColor"
       :name="props.iconName"
+      :can-hover="false"
       class="icon"
     />
     <slot />


### PR DESCRIPTION
Icon コンポーネントに CanHover Propsを実装しました。
CanHoverの値は省略可能で初期値がtrueになっています。
CanHoverがtrueの場合は、従来通りアイコンの色が変わります。
CanHoverがfalseの場合は、アイコンの色は変わりません。

CanHover Props are implemented in the Icon component.
The value of CanHover is optional and its initial value is true.
When CanHover is true, the color of the icon changes as before.
If CanHover is false, the icon color does not change.
