### PR TITLE
fix: message section background

### DIFF
--- a/apps/web/app/components/MessagePageSection.vue
+++ b/apps/web/app/components/MessagePageSection.vue
@@ -19,7 +19,7 @@
 
   padding: var(--container-padding);
   background: rgba(255, 255, 255, 0.75);
-  backdrop-filter: blur(2px);
+  backdrop-filter: blur(8px);
 }
 
 .content {


### PR DESCRIPTION
## issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/138

## 作業内容
トップページ、メッセージセクションの背景 `backdrop-filter` の値を修正しました。
[Figma](https://www.figma.com/file/g0oSNTSYpa0byRxVv00Ugm/Vue-Fes-Japan-2024?type=design&node-id=487%3A134820&mode=design&t=sp2E0nGJAw1zeFAm-1)

## 確認事項
@naramochi 
該当issueにもありましたが、一旦 `blur(8px)` として実装しましたので、ご確認お願いいたします。

**修正前**

![スクリーンショット 2024-04-17 23 20 27](https://github.com/vuejs-jp/vuefes-2024/assets/71963890/a202e221-3daf-4d12-ac78-71d3b9079942)


**修正後**

![スクリーンショット 2024-04-17 23 19 24](https://github.com/vuejs-jp/vuefes-2024/assets/71963890/7fc3e347-f143-454f-b996-cd96a33bf2aa)
