### PR TITLE
fix: form page section background

### DIFF
--- a/apps/web/app/components/FormPageSection.vue
+++ b/apps/web/app/components/FormPageSection.vue
@@ -102,7 +102,7 @@ const updateDetail = (e: any) => {
 section {
   position: relative;
   padding: 120px 20px 120px;
-  background-color: #fff;
+  background-image: linear-gradient(#fff, #ebf0f5);
   &::before {
     content: "";
     position: absolute;
@@ -110,11 +110,12 @@ section {
     inset: 0;
     width: 100%;
     height: 100%;
-    background-image: url('/form-bg.png'), linear-gradient(#fff, #ebf0f5);
+    background-image: url('/form-bg.png');
     background-size: auto;
     background-repeat: repeat;
     background-position: top left;
-    background-blend-mode: soft-light;
+    opacity: 0.8;
+    mix-blend-mode: overlay;
   }
 }
 


### PR DESCRIPTION
## issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/140

iOSで背景画像が正しく表示されない不具合の改修

## 原因
- iOSでのみ発生する不具合
- background-blend-modeはbackground-repeat:repeatなど、特定の状況下で機能しない。
- [バグレポート](https://bugs.webkit.org/show_bug.cgi?id=259081)

## 作業内容
background-blend-modeではなく、mix-blend-modeで実装。

## 検証環境
- Mac (macOS Sonoma 14.4.1) / Safari
- Windows 11 / Chrome, Edge, Firefox
- iPhone Xs Max (iOS 17.4.1) / Safari

## 確認事項
Androidが手元にないため、ご確認いただけると助かります。