### PR TITLE
fix/background size for sp

### DIFF
--- a/apps/web/app/components/FormPageSection.vue
+++ b/apps/web/app/components/FormPageSection.vue
@@ -163,6 +163,9 @@ form {
 @media (--mobile) {
   section {
     padding: 60px 20px 60px;
+    &::before {
+      background-size: 364px;
+    }
   }
   .form-root {
     gap: 30px;


### PR DESCRIPTION
## issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/140

スマホの背景画像サイズ対応

## 作業内容
スマホの時の背景画像を縮小

## 検証環境
- Mac / Safari
- Windows 11 / Chrome, Edge, Firefox
- iPhone Xs Max (iOS 17.4.1) / Safari
