### PR TITLE
refactor: Wrap page content in main tag for a11y, centralize in layouts

### DIFF
--- a/apps/web/app/layouts/default.vue
+++ b/apps/web/app/layouts/default.vue
@@ -13,7 +13,8 @@ useHead({
 
 <template>
   <GlobalHeader />
-  <div>
+  <main>
     <slot />
-  </div>
+  </main>
+  <FooterPageSection />
 </template>

--- a/apps/web/app/pages/code-of-conduct.vue
+++ b/apps/web/app/pages/code-of-conduct.vue
@@ -28,8 +28,8 @@ const { color } = useColor()
 </script>
 
 <template>
-  <main>
-    <div class="coc-root">
+  <div class="coc-root">
+    <div class="conducts">
       <h1
         :style="{
           fontWeight: fontWeight('heading/700'),
@@ -61,21 +61,20 @@ const { color } = useColor()
         {{ $t('back_to_top') }}
       </VFLinkButton>
     </div>
-  </main>
-  <FooterPageSection />
+  </div>
 </template>
 
 <style scoped>
 @import url('../assets/base.css');
-@import url("~/assets/media.css");
+@import url('~/assets/media.css');
 
-main {
+.coc-root {
   --header-height: calc(var(--unit) * 10);
 
   padding: calc(var(--header-height) + 120px) 20px 0;
   background: color(--color-white);
 }
-.coc-root {
+.conducts {
   display: grid;
   gap: 40px;
   max-width: 768px;
@@ -127,11 +126,11 @@ main {
 }
 
 @media (--mobile) {
-  main {
+  .coc-root {
     --header-height: calc(var(--unit) * 8);
     padding: calc(var(--header-height) + 60px) 20px 60px;
   }
-  .coc-root {
+  .conducts {
     gap: 30px;
   }
   .title {

--- a/apps/web/app/pages/index.vue
+++ b/apps/web/app/pages/index.vue
@@ -15,5 +15,4 @@ useHead({
   <MessagePageSection />
   <SponsorPageSection />
   <FormPageSection />
-  <FooterPageSection />
 </template>

--- a/apps/web/app/pages/privacy.vue
+++ b/apps/web/app/pages/privacy.vue
@@ -31,34 +31,31 @@ useHead({
 </script>
 
 <template>
-  <main>
-    <div
-      class="privacy-root"
-      :style="{
-        backgroundColor: color('white'),
-        color: color('vue-blue'),
-      }"
-    >
-      <h1 class="section-title">
-        {{ t('privacy.title') }}
-      </h1>
-      <div class="markdown-root">
-        <MarkDownText path="privacy" class="explain" />
-      </div>
-      <div class="back">
-        <VFLinkButton
-          class="back-action"
-          background-color="white"
-          color="vue-blue"
-          target=""
-          :href="`${localePath}/`"
-        >
-          {{ t('back_to_top') }}
-        </VFLinkButton>
-      </div>
+  <div
+    class="privacy-root"
+    :style="{
+      backgroundColor: color('white'),
+      color: color('vue-blue'),
+    }"
+  >
+    <h1 class="section-title">
+      {{ t('privacy.title') }}
+    </h1>
+    <div class="markdown-root">
+      <MarkDownText path="privacy" class="explain" />
     </div>
-  </main>
-  <FooterPageSection />
+    <div class="back">
+      <VFLinkButton
+        class="back-action"
+        background-color="white"
+        color="vue-blue"
+        target=""
+        :href="`${localePath}/`"
+      >
+        {{ t('back_to_top') }}
+      </VFLinkButton>
+    </div>
+  </div>
 </template>
 
 <style scoped>
@@ -122,7 +119,7 @@ useHead({
   & :deep(ul) li a:hover,
   & :deep(p) a:hover {
     opacity: 0.4;
-    transition: .2s;
+    transition: 0.2s;
   }
   /* 箇条書き1段目 reset.cssでnoneになったため追加 */
   & :deep(ul) {


### PR DESCRIPTION
## issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/210

## details of the changes
- pagesディレクトリ配下のmainタグ・フッターを、一箇所（layouts）で定義するよう変更した
- indexページをmainタグで囲うことで、axe devToolsのissueを解消した

## screenshot
### Before
![image](https://github.com/vuejs-jp/vuefes-2024/assets/39039737/03a57665-6f76-46c9-afab-082f6eb2e48d)

### After
※issue 1はNuxtの開発用ツールを対象としたものなので無視する
![Cursor_と_Vue_Fes_Japan_2024_と_code-of-conduct_vue__作業ツリー___code-of-conduct_vue__—_vuefes-2024](https://github.com/vuejs-jp/vuefes-2024/assets/39039737/79f964d7-3b87-40f6-a48a-5e3dc6581b84)


