### PR TITLE
Fix/title line height

### DIFF
--- a/apps/web/app/components/FormPageSection.vue
+++ b/apps/web/app/components/FormPageSection.vue
@@ -131,6 +131,7 @@ section {
 
 .title {
   text-align: center;
+  line-height: 1.2;
 }
 
 .subtitle {

--- a/apps/web/app/components/MessagePageSection.vue
+++ b/apps/web/app/components/MessagePageSection.vue
@@ -35,6 +35,7 @@
 
 .title {
   text-align: center;
+  line-height: 1.2;
 }
 
 .body {

--- a/apps/web/app/components/SponsorPageSection.vue
+++ b/apps/web/app/components/SponsorPageSection.vue
@@ -65,7 +65,6 @@ const { color } = useColor()
         </VFLinkButton>
       </div>
     </article>
-
   </div>
 </template>
 
@@ -85,18 +84,20 @@ const { color } = useColor()
   color: var(--color-vue-blue);
 }
 
+.title {
+  text-align: center;
+  line-height: 1.2;
+}
+
 .sponsor-body {
   margin: 0 auto;
   padding: var(--sponsor-body-padding);
   margin: 0 1.5%;
   background-color: white;
   max-width: 960px;
-  text-align: center;
-
 }
 
 .sponsor-text {
-  text-align: left;
   margin-top: calc(var(--unit) * 4);
   line-height: 1.8;
 
@@ -118,8 +119,10 @@ const { color } = useColor()
 }
 
 .sponsor-subtitle {
+  text-align: center;
+  line-height: 1.2;
   margin-top: calc(var(--unit) * 5);
-  margin-bottom: calc(var(--unit) * 2);
+  margin-bottom: calc(var(--unit) * 2.5);
   background: var(--color-vue-green-gradation);
   -webkit-text-fill-color: transparent;
   -webkit-background-clip: text;


### PR DESCRIPTION
## issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/146


1. 背景画像
  - グラデーションになっていない。
  - メインビジュアルの画像が見えている。
2. 見出し、本文のmargin
3. 送信ボタン
  - widthが100%になっていない。
  - 「送信」→「送信する」

1,3はすでに修正済みのため2を対応。

## 作業内容
### 2. 見出し、本文のmargin
[Figma](https://www.figma.com/file/g0oSNTSYpa0byRxVv00Ugm/Vue-Fes-Japan-2024?type=design&node-id=487-134881&mode=design&t=HsFTFKcnfR31yV9C-4)

- 見出しのline-heightを1.5から1.2へ修正
  - 問い合わせセクション以外の見出しも修正
- スポンサーセクションの副見出しも同様に1.5から1.2へ修正
  - marginの数値もデザインと異なっていたので修正
- スポンサーセクションのtext-alignの設定を他のセクションの設定と統一
  - セクション全体にtext-align:centerをあてるのではなく、titleにあてる。

## 確認事項
スポンサーセクションの副見出しはローカル環境でのみ確認済み
