### PR TITLE
feat: add public.sponsors

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -13,10 +13,9 @@ create table if not exists public.sponsors (
   image_url varchar(500) not null,
   speaker_id varchar(100) not null,
   is_personal int(10) not null,
-  category_ja varchar(100) not null,
-  category_en varchar(100) not null,
-  option_categories_ja varchar(100) [] not null,
-  option_categories_en varchar(100) [] not null,
+  category_ja varchar(100),
+  category_en varchar(100),
+  option_categories varchar(100) [] not null,
   created_at timestamp with time zone default timezone('utc' :: text, now()) not null,
   updated_at timestamp with time zone default timezone('utc' :: text, now()) not null
 );


### PR DESCRIPTION
# DB schema public.sponsors

以下を想定
- 個人スポンサーもこれでカバーする
- 上部のタグ？はタグの関連テーブルから任意の数を取得

name|description
-|-
id|プライマリキー
name|スポンサーの名前
description|スポンサーの説明
link_url|スポンサーのリンクurl
image_url|スポンサーイメージのurl
speaker_id|スピーカー情報のリレーションid
is_personal|個人スポンサーかどうか

![image](https://github.com/vuejs-jp/vuefes-2024/assets/6635142/9bf833c5-5a11-458a-a0b2-8187fd677ac4)
