### PR TITLE
Fix/locale switch contrast

### DIFF
--- a/packages/ui/components/common/LocaleSwitch.vue
+++ b/packages/ui/components/common/LocaleSwitch.vue
@@ -126,7 +126,7 @@ watch(
   right: 50%;
   height: 2rem;
   width: 2rem;
-  background: #34495e;
+  background: #283848;
   box-shadow: var(--box-shadow);
 }
 


### PR DESCRIPTION
## issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/229

## 作業内容
- a11yのコントラスト対応
- 言語切り替えスイッチの背景色を変更
- 修正後StorybookのAccessibilityチェックが解消されていることを確認

## スクリーンショット
<img width="455" alt="image" src="https://github.com/vuejs-jp/vuefes-2024/assets/19932579/80452785-614e-42c4-83e1-cfb2b6590d20">
