### PR TITLE
FIx/reset locale state

### DIFF
--- a/apps/web/app/composables/useLocaleCurrent.ts
+++ b/apps/web/app/composables/useLocaleCurrent.ts
@@ -1,7 +1,8 @@
+import { computed } from 'vue'
 import { useI18n } from '#imports'
 
 export function useLocaleCurrent() {
   const { locale } = useI18n({ useScope: 'global' })
-  const path = locale.value === 'ja' ? '' : `/${locale.value}`
+  const path = computed(() => locale.value === 'ja' ? '' : `/${locale.value}`)
   return { locale, path }
 }


### PR DESCRIPTION
## issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/235

## 詳細
- useLocaleCurrent内、pathの取得をcomputedで定義するように変更

## 影響範囲・テスト
- code-of-conduct.vue
- privacy.vue
- FooterPageSection.vue

※ローカル環境で確認済

## キャプチャ
### before
https://github.com/vuejs-jp/vuefes-2024/assets/19932579/27db9aff-6269-4613-9423-19373e6fd108
### after
https://github.com/vuejs-jp/vuefes-2024/assets/19932579/5d460bcb-fa50-4e8e-8f17-9e2d2868f6fb

