### PR TITLE
fix: Safari で grid 表示の `place-items: center` が効かない問題を修正

### DIFF
--- a/apps/web/app/components/FooterPageSection.vue
+++ b/apps/web/app/components/FooterPageSection.vue
@@ -169,6 +169,7 @@ const vueFesLinkList: LinkList[] = [
     aspect-ratio: 1;
     display: grid;
     place-items: center;
+    width: 100%;
   }
   @media (--mobile) {
     :deep(svg) {


### PR DESCRIPTION
すごく細かいですが、Safari (Mac PC) で気づいた表示崩れの対応 PR となります。
内容としては、Safari だとフッターにあるアイコンボタンが上の方に偏っているというものです (下図参照)

<img width="308" alt="Vue_Fes_Japan_2024" src="https://github.com/vuejs-jp/vuefes-2024/assets/20141403/1899d723-6697-4710-89c8-a4d231bf8e0d">

内容は軽微なので issue 立てずにそのまま PR 出しています。
取り急ぎレビュアーに @jiyuujin さんを設定しています🙏

**確認事項**

PR 対応後は下図の右部のように、Safari 上でも各アイコンが上下左右揃えになっていることを確認済みです。
また、確認できる範囲で他ブラウザ (Chome, Firefox, Edge) でも、PR 前後で表示崩れしていないことも確認済みです。

<img width="658" alt="Vue_Fes_Japan_2024_と_Vue_Fes_Japan_2024" src="https://github.com/vuejs-jp/vuefes-2024/assets/20141403/817ffff3-dd56-46a5-93bf-96c2559f12d1">