### PR TITLE
RLS to public.staffs, public.speakers, public.sponsors and public.attendees

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -135,6 +135,21 @@ create table if not exists public.attendees (
 
 ALTER TABLE public.attendees ADD COLUMN image_file_name uuid not null unique default uuid_generate_v4();
 
+alter table
+  public.attendees enable row level security;
+
+create policy "Allow select for all attendees." on public.attendees for
+select
+  using (true);
+
+create policy "Allow insert for all attendees." on public.attendees for
+insert
+  with check (true);
+
+create policy "Allow update for all attendees." on public.attendees for
+update
+  using (true);
+
 -- *** Function definitions ***
 create
 or replace function public.create_admin_user() returns trigger as $ $ begin -- If user_role is 'admin', insert data into admin_users table


### PR DESCRIPTION
RLS 方針を仕込みました（すでに Supabase 反映済み、PR 環境で表示・裏で操作できることは確認済み
なお、各テーブルの方針は一旦同じに設定しています

cc: @vuejs-jp/vuefes-2024-maintainer 

### 一旦、全許可させていただく
- select
- insert
- update

### 記載無し
- delete
   - 現時点で裏側の管理画面上には削除の機能を搭載していないので

### 時間あれば、厳密なアクセス制御を進められると良い
- insert
- update
