### PR TITLE
feat(auth): add middleware for session validation

### DIFF
--- a/apps/web/app/composables/useAuth.ts
+++ b/apps/web/app/composables/useAuth.ts
@@ -1,11 +1,11 @@
 import { useSupabaseClient } from '#imports'
-import type { AuthProvider, RedirectPath } from '@vuejs-jp/model'
+import type { AuthProvider } from '@vuejs-jp/model'
 import { REDIRECT_URL } from '~/utils/environment.constants'
 
 export function useAuth() {
   const supabase = useSupabaseClient()
 
-  async function signIn(provider: Extract<AuthProvider, 'github' | 'google'>, path: RedirectPath) {
+  async function signIn(provider: Extract<AuthProvider, 'github' | 'google'>, path: string) {
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
@@ -22,5 +22,17 @@ export function useAuth() {
     }
   }
 
-  return { signIn, signOut }
+  async function getUser() {
+    const { data,error } = await supabase.auth.getUser()
+    if (error) {
+      throw new Error('can not get user')
+    }
+   return data.user
+  }
+
+  const authUserId = getUser().then(user => {
+    return user.id
+  }).catch(()=> null)
+
+  return { signIn, signOut, authUserId }
 }

--- a/apps/web/app/middleware/auth.ts
+++ b/apps/web/app/middleware/auth.ts
@@ -1,0 +1,10 @@
+// nuxt.config.ts でページ全体へ適応するのではなく、個別でpageコンポーネントに適応する想定
+import { defineNuxtRouteMiddleware, navigateTo, useAuthSession } from '#imports'
+
+export default defineNuxtRouteMiddleware(async () => {
+  const { hasAuth } = useAuthSession()
+
+  if (!hasAuth?.value) {
+    return navigateTo('/namecard/')
+  }
+})

--- a/apps/web/app/pages/namecard/[id]/index.vue
+++ b/apps/web/app/pages/namecard/[id]/index.vue
@@ -1,2 +1,20 @@
-<script setup lang="ts"></script>
-<template></template>
+<script setup lang="ts">
+import { definePageMeta } from '#imports'
+definePageMeta({
+  middleware: 'auth',
+})
+</script>
+<template>
+  <div class="name-card-user-root">
+    <VFLinkButton is="button" background-color="vue-green/200" color="white" href=""
+      >hoge</VFLinkButton
+    >
+  </div>
+</template>
+
+<style scoped>
+.name-card-user-root {
+  --header-height: calc(var(--unit) * 10);
+  padding-top: var(--header-height);
+}
+</style>

--- a/apps/web/app/pages/namecard/index.vue
+++ b/apps/web/app/pages/namecard/index.vue
@@ -2,7 +2,8 @@
 import { ref } from 'vue'
 import type { AuthProvider } from '@vuejs-jp/model'
 import { useAuth } from '~/composables/useAuth'
-import { createError, useRuntimeConfig } from '#imports'
+import { useAuthSession } from '#imports'
+import { createError, useRuntimeConfig, navigateTo } from '#imports'
 
 const config = useRuntimeConfig()
 
@@ -11,11 +12,12 @@ if (!config.public.enableRegisterNamecard) {
 }
 
 const showDialog = ref(false)
-const { signIn } = useAuth()
+const { signIn, authUserId } = useAuth()
+const { hasAuth } = useAuthSession()
 
 function handleClickButton(type: 'open' | 'close') {
-  // TODO セッション確認を行い、ログイン済みの場合はリダイレクト処理を実行しあと工程スキップ
   if (type === 'open') {
+    if (hasAuth?.value) return navigateTo(`/namecard/${authUserId}/`)
     showDialog.value = true
   } else {
     showDialog.value = false
@@ -23,8 +25,7 @@ function handleClickButton(type: 'open' | 'close') {
 }
 
 function handleSignIn(provider: Extract<AuthProvider, 'github' | 'google'>) {
-  // TODO リダイレクト先は namecard/[id]/ とする（編集画面作成時に変更） ローカル開発用にフルパス指定（環境変数で振り分け）した方が便利
-  signIn(provider, '/')
+  signIn(provider, `/namecard/${authUserId}/`)
 }
 </script>
 

--- a/packages/model/lib/auth.ts
+++ b/packages/model/lib/auth.ts
@@ -1,3 +1,1 @@
 export type AuthProvider = 'github' | 'google' | 'x'
-
-export type RedirectPath = '/'


### PR DESCRIPTION
## Details of the changes
- 認証用ミドルウェアの追加
- namecart/[id]/ のidをsupabase.authのidを利用するようにした

※細かい挙動調整は各ページ作成時に行うため、一旦マージして他作業進めます。