### PR TITLE
feat: ticketName to role

### DIFF
--- a/apps/peatix-adapter/src/constnats.ts
+++ b/apps/peatix-adapter/src/constnats.ts
@@ -1,4 +1,10 @@
 export const Constants = {
   PEATIX_LOGIN_URL: 'https://peatix.com/signin',
   PEATIX_DASHBOARD_URL: 'https://peatix.com/event/',
-}
+  PEATIX_GENERAL_TICKET: '一般チケット',
+  PEATIX_WITH_PARTY_TICKET: '一般＋アフターパーティーチケット',
+  PEATIX_GENERAL_ROLE: 'attendee',
+  PEATIX_WITH_PARTY_ROLE: 'attendee + party',
+} as const
+
+export type TicketRole = Extract<typeof Constants[keyof typeof Constants], 'attendee' | 'attendee + party'>

--- a/apps/peatix-adapter/src/peatix-order/peatix-order.service.ts
+++ b/apps/peatix-adapter/src/peatix-order/peatix-order.service.ts
@@ -174,8 +174,14 @@ export class PeatixOrderService extends ScraperPage {
             const ticketName = attendee[Object.keys(attendee)[4]]
 
             // チケット名から参加者の種別を特定する
+            if (ticketName.includes(Constants.PEATIX_GENERAL_TICKET)) {
+              return { role: Constants.PEATIX_GENERAL_ROLE, receipt_id: receiptId }
+            }
+            if (ticketName.includes(Constants.PEATIX_WITH_PARTY_TICKET)) {
+              return { role: Constants.PEATIX_WITH_PARTY_ROLE, receipt_id: receiptId }
+            }
 
-            return { role: 'attendee', receipt_id: receiptId }
+            // return { role: 'attendee', receipt_id: receiptId }
           })
           this.logger.log(receipts)
 

--- a/apps/peatix-adapter/src/types/supabase.ts
+++ b/apps/peatix-adapter/src/types/supabase.ts
@@ -1,4 +1,5 @@
 import { Role } from '@vuejs-jp/model'
+import { TicketRole } from '../constnats'
 
 export type { Database } from './generated/supabase'
 
@@ -7,6 +8,6 @@ export type FormAttendee = Database['public']['Tables']['attendees']['Insert']
 export type FormAdminUser = Database['public']['Tables']['admin_users']['Insert']
 
 export type AttendeeReceipt = {
-  role: Extract<Role, 'attendee' | 'attendee + party'>
+  role: Extract<Role, TicketRole>
   receipt_id: string
 }


### PR DESCRIPTION
https://github.com/vuejs-jp/vuefes-2024-backside/issues/226

### Peatix

チケット種別は下記の通り、チケット名から参加者種別を判定するのを目指す

<img width="941" alt="スクリーンショット 2024-07-13 16 24 04" src="https://github.com/user-attachments/assets/c865ede5-6deb-4a04-9e77-d70aa009839d">
