### PR TITLE
rename caption to company, add position (separate to description)

### DIFF
--- a/apps/web/app/components/SpeakerPageSection.vue
+++ b/apps/web/app/components/SpeakerPageSection.vue
@@ -31,8 +31,8 @@ const { sessionSpeakers, lightningTalkSpeakers, sponsorSessionSpeakers } = data.
           <li v-for="speaker in sessionSpeakers.list" :key="speaker.id" class="speaker-card">
             <VFSpeaker
               :image="speaker.image_url"
-              :company="currentLocale === 'en' ? speaker.caption_en : speaker.caption_ja"
-              :division="currentLocale === 'en' ? speaker.description_en : speaker.description_ja"
+              :company="currentLocale === 'en' ? speaker.company_en : speaker.company_ja"
+              :division="currentLocale === 'en' ? speaker.position_en : speaker.position_ja"
               :name="currentLocale === 'en' ? speaker.name_en : speaker.name_ja"
               :github-id="speaker.github_id"
               :x-id="speaker.x_id"
@@ -47,8 +47,8 @@ const { sessionSpeakers, lightningTalkSpeakers, sponsorSessionSpeakers } = data.
           <li v-for="speaker in lightningTalkSpeakers.list" :key="speaker.id" class="speaker-card">
             <VFSpeaker
               :image="speaker.image_url"
-              :company="currentLocale === 'en' ? speaker.caption_en : speaker.caption_ja"
-              :division="currentLocale === 'en' ? speaker.description_en : speaker.description_ja"
+              :company="currentLocale === 'en' ? speaker.company_en : speaker.company_ja"
+              :division="currentLocale === 'en' ? speaker.position_en : speaker.position_ja"
               :name="currentLocale === 'en' ? speaker.name_en : speaker.name_ja"
               :github-id="speaker.github_id"
               :x-id="speaker.x_id"
@@ -63,8 +63,8 @@ const { sessionSpeakers, lightningTalkSpeakers, sponsorSessionSpeakers } = data.
           <li v-for="speaker in sponsorSessionSpeakers.list" :key="speaker.id" class="speaker-card">
             <VFSpeaker
               :image="speaker.image_url"
-              :company="currentLocale === 'en' ? speaker.caption_en : speaker.caption_ja"
-              :division="currentLocale === 'en' ? speaker.description_en : speaker.description_ja"
+              :company="currentLocale === 'en' ? speaker.company_en : speaker.company_ja"
+              :division="currentLocale === 'en' ? speaker.position_en : speaker.position_ja"
               :name="currentLocale === 'en' ? speaker.name_en : speaker.name_ja"
               :github-id="speaker.github_id"
               :x-id="speaker.x_id"

--- a/apps/web/app/components/admin/SpeakerItem.vue
+++ b/apps/web/app/components/admin/SpeakerItem.vue
@@ -19,8 +19,10 @@ const newSpeaker = ref<FormSpeaker>({
   name_en: props.speaker?.name_en ?? '',
   detail_page_id: props.speaker?.detail_page_id ?? '',
   image_url: props.speaker?.image_url ?? '',
-  caption_ja: props.speaker?.caption_ja ?? '',
-  caption_en: props.speaker?.caption_en ?? '',
+  company_ja: props.speaker?.company_ja ?? '',
+  company_en: props.speaker?.company_en ?? '',
+  position_ja: props.speaker?.position_ja ?? '',
+  position_en: props.speaker?.position_en ?? '',
   description_ja: props.speaker?.description_ja ?? '',
   description_en: props.speaker?.description_en ?? '',
   github_id: props.speaker?.github_id ?? '',
@@ -65,11 +67,17 @@ const checkFiles = async (files: File[]) => {
 
   newSpeaker.value.image_url = getFullAvatarUrl(filePath)
 }
-const updateCaptionJa = (e: any) => {
-  newSpeaker.value.caption_ja = e.target.value
+const updateCompanyJa = (e: any) => {
+  newSpeaker.value.company_ja = e.target.value
 }
-const updateCaptionEn = (e: any) => {
-  newSpeaker.value.caption_en = e.target.value
+const updateCompanyEn = (e: any) => {
+  newSpeaker.value.company_en = e.target.value
+}
+const updatePositionJa = (e: any) => {
+  newSpeaker.value.position_ja = e.target.value
+}
+const updatePositionEn = (e: any) => {
+  newSpeaker.value.position_en = e.target.value
 }
 const updateDescriptionJa = (e: any) => {
   newSpeaker.value.description_ja = e.target.value
@@ -138,18 +146,32 @@ const onSubmit = () => {
           </div>
         </VFDragDropArea>
         <VFInputField
-          id="caption_ja"
-          v-model="newSpeaker.caption_ja"
-          name="caption_ja"
-          label="肩書き [JA]"
-          @input="updateCaptionJa"
+          id="company_ja"
+          v-model="newSpeaker.company_ja"
+          name="company_ja"
+          label="企業 [JA]"
+          @input="updateCompanyJa"
         />
         <VFInputField
-          id="caption_en"
-          v-model="newSpeaker.caption_en"
-          name="caption_en"
+          id="company_en"
+          v-model="newSpeaker.company_en"
+          name="company_en"
+          label="企業 [EN]"
+          @input="updateCompanyEn"
+        />
+        <VFInputField
+          id="position_ja"
+          v-model="newSpeaker.position_ja"
+          name="position_ja"
+          label="肩書き [JA]"
+          @input="updatePositionJa"
+        />
+        <VFInputField
+          id="position_en"
+          v-model="newSpeaker.position_en"
+          name="position_ja"
           label="肩書き [EN]"
-          @input="updateCaptionEn"
+          @input="updatePositionEn"
         />
         <VFTextAreaField
           id="description_ja"

--- a/apps/web/app/components/admin/SpeakerList.vue
+++ b/apps/web/app/components/admin/SpeakerList.vue
@@ -24,7 +24,8 @@ const handleDialog = (id?: string) => {
       <th>name</th>
       <th>detail_page_id</th>
       <th>image_url</th>
-      <th>caption</th>
+      <th>company</th>
+      <th>position</th>
       <th>description</th>
       <th>github_id</th>
       <th>x_id</th>
@@ -52,8 +53,12 @@ const handleDialog = (id?: string) => {
         </p>
       </td>
       <td>
-        <p>{{ speaker.caption_ja }}</p>
-        <p>{{ speaker.caption_en }}</p>
+        <p>{{ speaker.company_ja }}</p>
+        <p>{{ speaker.company_en }}</p>
+      </td>
+      <td>
+        <p>{{ speaker.position_ja }}</p>
+        <p>{{ speaker.position_en }}</p>
       </td>
       <td>
         <p>{{ speaker.description_ja }}</p>

--- a/apps/web/app/pages/sessions/[id]/index.vue
+++ b/apps/web/app/pages/sessions/[id]/index.vue
@@ -56,8 +56,8 @@ useHead({
       <div class="detailbody-persons">
         <VFSpeaker
           :image="speakerData[0].image_url"
-          :company="currentLocale === 'en' ? speakerData[0].caption_en : speakerData[0].caption_ja"
-          :division="currentLocale === 'en' ? speakerData[0].description_en : speakerData[0].description_ja"
+          :company="currentLocale === 'en' ? speakerData[0].company_en : speakerData[0].company_ja"
+          :division="currentLocale === 'en' ? speakerData[0].position_en : speakerData[0].position_ja"
           :name="currentLocale === 'en' ? speakerData[0].name_en : speakerData[0].name_ja"
           :github-id="speakerData[0].github_id"
           :x-id="speakerData[0].x_id"

--- a/apps/web/app/types/generated/supabase.ts
+++ b/apps/web/app/types/generated/supabase.ts
@@ -156,8 +156,8 @@ export type Database = {
       }
       speakers: {
         Row: {
-          caption_en: string | null
-          caption_ja: string | null
+          company_en: string | null
+          company_ja: string | null
           created_at: string
           description_en: string
           description_ja: string
@@ -170,6 +170,8 @@ export type Database = {
           is_open: boolean
           name_en: string
           name_ja: string
+          position_en: string | null
+          position_ja: string | null
           session_comment_en: string | null
           session_comment_ja: string | null
           session_description_en: string | null
@@ -187,8 +189,8 @@ export type Database = {
           x_id: string | null
         }
         Insert: {
-          caption_en?: string | null
-          caption_ja?: string | null
+          company_en?: string | null
+          company_ja?: string | null
           created_at?: string
           description_en: string
           description_ja: string
@@ -201,6 +203,8 @@ export type Database = {
           is_open: boolean
           name_en: string
           name_ja: string
+          position_en: string | null
+          position_ja: string | null
           session_comment_en?: string | null
           session_comment_ja?: string | null
           session_description_en?: string | null
@@ -218,8 +222,8 @@ export type Database = {
           x_id?: string | null
         }
         Update: {
-          caption_en?: string | null
-          caption_ja?: string | null
+          company_en?: string | null
+          company_ja?: string | null
           created_at?: string
           description_en?: string
           description_ja?: string
@@ -232,6 +236,8 @@ export type Database = {
           is_open?: boolean
           name_en?: string
           name_ja?: string
+          position_en: string | null
+          position_ja: string | null
           session_comment_en?: string | null
           session_comment_ja?: string | null
           session_description_en?: string | null

--- a/packages/model/lib/speaker.ts
+++ b/packages/model/lib/speaker.ts
@@ -14,8 +14,10 @@ export type Speaker = {
   name_en: string
   detail_page_id?: string
   image_url?: string
-  caption_ja?: string
-  caption_en?: string
+  company_ja?: string
+  company_en?: string
+  position_ja?: string
+  position_en?: string
   description_ja: string
   description_en: string
   github_id?: string

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -114,6 +114,14 @@ ALTER TABLE public.speakers ADD COLUMN detail_page_id varchar(40);
 
 ALTER TABLE public.speakers ADD COLUMN events text array;
 
+ALTER TABLE public.speakers RENAME COLUMN caption_ja TO company_ja;
+
+ALTER TABLE public.speakers RENAME COLUMN caption_en TO company_en;
+
+ALTER TABLE public.speakers ADD COLUMN position_ja varchar(100);
+
+ALTER TABLE public.speakers ADD COLUMN position_en varchar(100);
+
 alter table
   public.speakers enable row level security;
 


### PR DESCRIPTION
当初から盛り込まれている toshick さんの考えられていた設計をやめました
-> company と division しかなく、企業名と肩書きとスピーカー紹介の 3点入らなかったため

- company -> 企業や組織を入力する
- position -> 肩書きを入力する
- description -> 自己紹介を入力する

一応、スピーカーをレビュー・タイムテーブルに着手される @yamageji さんを中心に、ご一読いただければ mm

@yamageji cc: @vuejs-jp/vuefes-2024-maintainer 

=====

（余談）

データ切り替え、更新はすでに完了しています

<img width="1591" alt="スクリーンショット 2024-07-24 22 56 06" src="https://github.com/user-attachments/assets/f8c3dfe2-f01b-4e29-993d-7c5e74ab89d8">
