### PR TITLE
update after-purchase

### DIFF
--- a/apps/peatix-adapter/src/after-purchase/after-purchase.service.ts
+++ b/apps/peatix-adapter/src/after-purchase/after-purchase.service.ts
@@ -19,38 +19,46 @@ export class AfterPurchaseService {
 
   async apply() {
     const orders = await this.peatixOrderService.getOrders()
-    this.logger.log(orders)
+    // this.logger.log(orders)
 
-    const receipts: AttendeeReceipt[] = orders.map((attendee) => {
-      const receiptId = attendee[Object.keys(attendee)[0]]
-      const ticketName = attendee[Object.keys(attendee)[4]]
+    const receipts: AttendeeReceipt[] = orders
+      .map((attendee) => {
+        const receiptId = attendee[Object.keys(attendee)[Constants.PEATIX_RECEIPT_ID_ROW_INDEX]]
+        const ticketName = attendee[Object.keys(attendee)[Constants.PEATIX_RECEIPTS_TICKET_NAME_ROW_INDEX]]
 
-      // チケット名から参加者の種別を特定する
-      if (ticketName.includes(Constants.PEATIX_GENERAL_TICKET)) {
-        return { role: Constants.PEATIX_GENERAL_ROLE, receipt_id: receiptId }
-      }
-      if (ticketName.includes(Constants.PEATIX_WITH_PARTY_TICKET)) {
-        return { role: Constants.PEATIX_WITH_PARTY_ROLE, receipt_id: receiptId }
-      }
+        // チケット名から参加者の種別を特定する
+        if (ticketName.includes(Constants.PEATIX_GENERAL_TICKET)) {
+          return { role: Constants.PEATIX_GENERAL_ROLE, receipt_id: receiptId }
+        }
+        if (ticketName.includes(Constants.PEATIX_WITH_PARTY_TICKET)) {
+          return { role: Constants.PEATIX_WITH_PARTY_ROLE, receipt_id: receiptId }
+        }
 
-      // return { role: 'attendee', receipt_id: receiptId }
-    })
-    this.logger.log(receipts)
+        // return { role: 'attendee', receipt_id: receiptId }
+      })
+      .filter(v => v) // null は除外
+    const personalSponsors: string[] = orders
+      .map((attendee) => attendee[Object.keys(attendee)[Constants.PEATIX_PERSONAL_SPONSOR_NAME_ROW_INDEX]])
+      .filter(v => v) // null は除外
+    // this.logger.log(receipts)
+    this.logger.log(personalSponsors)
 
     this.discordService.send('After Purchase Bot', `${receipts.length}件 購入済`)
 
-    // let i = 0
+    let i = 0
 
     // Peatix 購入情報を Supabase へ反映する
     for (const receipt of receipts) {
       this.logger.log(receipt)
-      // const result = await this.supabaseService.updateAttendees(receipt)
-      // if (!result) {
-      //   break
-      // }
-      // i += 1
+      const result = await this.supabaseService.updateAttendees(receipt)
+      if (result.status === false) {
+        // break
+      }
+      if (result.data !== null) {
+        i += 1
+      }
     }
 
-    // this.discordService.send('After Purchase Bot', `${receipts.length}件 購入済 / ${i}件 反映済`)
+    this.discordService.send('After Purchase Bot', `${receipts.length}件 購入済 / ${i}件 反映済`)
   }
 }

--- a/apps/peatix-adapter/src/constnats.ts
+++ b/apps/peatix-adapter/src/constnats.ts
@@ -5,6 +5,9 @@ export const Constants = {
   PEATIX_WITH_PARTY_TICKET: '一般＋アフターパーティーチケット',
   PEATIX_HANDSON_TICKET: 'ハンズオンチケット',
   PEATIX_PERSONAL_SPONSOR_TICKET: '個人スポンサーチケット',
+  PEATIX_RECEIPT_ID_ROW_INDEX: 0, // レシート ID
+  PEATIX_RECEIPTS_TICKET_NAME_ROW_INDEX: 4, // チケット名
+  PEATIX_PERSONAL_SPONSOR_NAME_ROW_INDEX: 15, // 個人スポンサー クレジット名
   PEATIX_GENERAL_ROLE: 'attendee',
   PEATIX_WITH_PARTY_ROLE: 'attendee + party',
 } as const

--- a/apps/peatix-adapter/src/supabase/supabase.service.ts
+++ b/apps/peatix-adapter/src/supabase/supabase.service.ts
@@ -42,8 +42,8 @@ export class SupabaseService {
       .upsert({ role: targetData.role, activated_at: new Date().toISOString() })
       .eq('receipt_id', targetData.receipt_id)
       .eq('activated_at', null)
-    if (error) false
+    if (error) return { status: false, data: null }
 
-    return true
+    return { status: true, data }
   }
 }


### PR DESCRIPTION
cc: @vuejs-jp/vuefes-2024-maintainer 

- ざっとチケット名の判定、レシート ID の取得は行けてそう
   - データ件数が増えても -> これから注視する必要
- 個人スポンサーもざっくりクレジット名を取得できる

### 実行結果

https://github.com/vuejs-jp/vuefes-2024-backside/issues/226#issuecomment-2254912712