### PR TITLE
[8/2 AM Merge] fix: filter query (speakers)

### DIFF
--- a/apps/web/app/server/api/speakers.get.ts
+++ b/apps/web/app/server/api/speakers.get.ts
@@ -31,9 +31,8 @@ export default defineEventHandler(async (event) => {
         return speaker.session_type === 'session'
       })
       .sort((a: Speaker, b: Speaker) => {
-        if (!a.display_order) return a.created_at < b.created_at ? -1 : 1
-        if (!b.display_order) return a.created_at < b.created_at ? -1 : 1
-        return a.display_order - b.display_order
+        if (b.display_order && a.display_order) return a.display_order - b.display_order
+        return a.created_at < b.created_at ? -1 : 1
       }),
   }
 
@@ -46,9 +45,7 @@ export default defineEventHandler(async (event) => {
         return speaker.session_type === 'lightning-talk'
       })
       .sort((a: Speaker, b: Speaker) => {
-        if (!a.display_order) return a.created_at < b.created_at ? -1 : 1
-        if (!b.display_order) return a.created_at < b.created_at ? -1 : 1
-        return a.display_order - b.display_order
+        return a.created_at < b.created_at ? -1 : 1
       }),
   }
 
@@ -61,9 +58,7 @@ export default defineEventHandler(async (event) => {
         return speaker.session_type === 'sponsor-session'
       })
       .sort((a: Speaker, b: Speaker) => {
-        if (!a.display_order) return a.created_at < b.created_at ? -1 : 1
-        if (!b.display_order) return a.created_at < b.created_at ? -1 : 1
-        return a.display_order - b.display_order
+        return a.created_at < b.created_at ? -1 : 1
       }),
   }
 
@@ -78,9 +73,8 @@ export default defineEventHandler(async (event) => {
           return s['events'].includes('welcome-vuejs-community')
         })
         .sort((a: Speaker, b: Speaker) => {
-          if (!a.display_order) return a.created_at < b.created_at ? -1 : 1
-          if (!b.display_order) return a.created_at < b.created_at ? -1 : 1
-          return a.display_order - b.display_order
+          if (b.display_order && a.display_order) return a.display_order - b.display_order
+          return a.created_at < b.created_at ? -1 : 1
         }),
       'nextgen-frontend-crosstalk': allSpeakers
         .filter((s: Speaker) => {
@@ -89,9 +83,8 @@ export default defineEventHandler(async (event) => {
           return s['events'].includes('nextgen-frontend-crosstalk')
         })
         .sort((a: Speaker, b: Speaker) => {
-          if (!a.display_order) return a.created_at < b.created_at ? -1 : 1
-          if (!b.display_order) return a.created_at < b.created_at ? -1 : 1
-          return a.display_order - b.display_order
+          if (b.display_order && a.display_order) return a.display_order - b.display_order
+          return a.created_at < b.created_at ? -1 : 1
         }),
     },
   }


### PR DESCRIPTION
CfP スピーカー公開にあたって、以下の順序に並ぶよう、クエリを修正しました mm

1. 海外ゲスト
2. 国内ゲスト
3. 英語CFPスピーカー
4. 日本語CFPスピーカー

https://github.com/vuejs-jp/vuefes-2024-backside/issues/191
