### PR TITLE
style: adjust font size to fit names up to 12 full-width characters o…

### DIFF
--- a/packages/ui/components/namecard/Namecard24.stories.ts
+++ b/packages/ui/components/namecard/Namecard24.stories.ts
@@ -4,6 +4,9 @@ import Namecard24 from './Namecard24.vue'
 export default {
   title: 'namecard/Namecard24',
   component: Namecard24,
+  argTypes: {
+    user:{ control: 'object' },
+  },
   args: {
     user: {
       display_name: 'jiyuujin',
@@ -68,4 +71,13 @@ NoAvatar.args = {
     role: 'attendee',
   },
   isPlaceholder: true,
+}
+
+export const FullWidthCharacters12 = Template.bind({})
+FullWidthCharacters12.args = {
+  user: {
+    display_name: '上上上上上上上上上上上上',
+    avatar_url: '',
+    role: 'attendee',
+  },
 }

--- a/packages/ui/components/namecard/NamecardAvatar24.vue
+++ b/packages/ui/components/namecard/NamecardAvatar24.vue
@@ -98,7 +98,8 @@ onMounted(() => {
 }
 
 .avatar-name-area {
-  width: 85cqi;
+  --name-area-width: 85cqi;
+  width: var(--name-area-width);
   height: 8rem;
   background-color: var(--color-white);
   margin-top: 0.8125rem;
@@ -118,13 +119,10 @@ onMounted(() => {
 .avatar-name {
   --color-avatar-name: color-mix(in srgb, var(--color-vue-blue), #000 20%);
 
-  font-size: 2.25rem;
+  font-size: calc(var(--name-area-width) / 12);
   font-weight: 700;
   line-height: 1.1;
   color: var(--color-avatar-name);
-  @media (width <= 480px) {
-    font-size: 1.6875rem;
-  }
 }
 
 .avatar-footer {


### PR DESCRIPTION
## Issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/360#issuecomment-2257342292

## Details
- ネームカードプレビュー｜全角12文字までは1行で表示されるよう調整した
フォントサイズを名前表示エリアの横幅から算出するようにしました

## Screenshots
![namecard___Namecard24_-_Full_Width_Characters_12_⋅_Storybook](https://github.com/user-attachments/assets/4207453b-bf96-4511-b276-0ddc99991103)
![namecard___Namecard24_-_Full_Width_Characters_12_⋅_Storybook](https://github.com/user-attachments/assets/b7666f91-2e27-4dc6-aeb5-5c5dec8a7186)
