### PR TITLE
fix: ajust font-size on namecard

### DIFF
--- a/packages/ui/components/namecard/NamecardAvatar24.vue
+++ b/packages/ui/components/namecard/NamecardAvatar24.vue
@@ -99,6 +99,7 @@ onMounted(() => {
 
 .avatar-name-area {
   --name-area-width: 85cqi;
+  --name-area-padding: 1rem;
   width: var(--name-area-width);
   height: 8rem;
   background-color: var(--color-white);
@@ -106,7 +107,7 @@ onMounted(() => {
   display: grid;
   place-items: center;
   border-radius: calc(var(--unit) * 1.25);
-  padding-inline: 1rem;
+  padding-inline: var(--name-area-padding);
   overflow-wrap: anywhere;
   word-break: break-all;
   overflow-y: hidden;
@@ -119,7 +120,7 @@ onMounted(() => {
 .avatar-name {
   --color-avatar-name: color-mix(in srgb, var(--color-vue-blue), #000 20%);
 
-  font-size: calc(var(--name-area-width) / 12);
+  font-size: calc((var(--name-area-width) - var(--name-area-padding) * 2) / 12);
   font-weight: 700;
   line-height: 1.1;
   color: var(--color-avatar-name);


### PR DESCRIPTION
namecardコンポーネントのフォントサイズ調整
コンポーネント利用時も、全角12文字が入るように調整した
![Vue_Fes_Japan_2024](https://github.com/user-attachments/assets/aac86b6a-dfa4-40ea-8ce1-0eb198a2ab11)
