### PR TITLE
fix: fix typo in en.json

### DIFF
--- a/apps/web/app/lang/en.json
+++ b/apps/web/app/lang/en.json
@@ -44,7 +44,7 @@
     "payment_method_explain": "There are two methods of payment.",
     "preorder": "Pre-Order",
     "caution": "The product image is for illustrative purposes. Actual product colors and details may differ.",
-    "tshirt": "T-Shirts",
+    "tshirt": "T-shirts",
     "tshirt_size": "Size: S / M / L / XL",
     "tshirt_detail": "This is an original T-shirt for Vue Fes Japan 2024, inspired by Mount Fuji and the sun. It features a print only on the front.",
     "parka": "Hooded sweatshirt",


### PR DESCRIPTION
### 🔗 Linked issue

related #185 , #243 

### 📚 Description

- [x] 英語版で表示した時に以下2点の表記誤りを発見。こちら修正しました
  - [x] `T-shirts`のtypo
  - [x] ロゴステッカーが日本語表記のままだった
