### PR TITLE
Fix: Add X-Robots-Tag header to prevent indexing

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -50,3 +50,8 @@ status = 301
 
 [functions.server]
 external_node_modules = ["chrome-aws-lambda"]
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Robots-Tag = "noindex"


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/377

### 📚 Description
- [x] netlify.toml にX-Robots-Tagを追加。
- [ ] preview環境はもともとレスポンスヘッダーにX-Robots-Tagが設定されているので、[https://vuefes-2024.netlify.app/2024/](https://vuefes-2024.netlify.app/2024/)にはマージしてからレスポンスヘッダーを確認しないとわからない。
  - [x] 同様の設定を個人プロジェクトで試して設定されているところまで確認済み。
- [ ] X-Robots-Tagが設定されているのが確認できたら[Bing Webmaster Tools](https://www.bing.com/webmasters/about?cc=jp)から削除申請する必要がありそう。
- [ ] 上記対応でX-Robots-Tagがレスポンスヘッダーに設定されていない場合_headers ファイルを作成して試す。
  - 参考：https://answers.netlify.com/t/x-robots-tag-noindex-set-this-in-netlify-toml-file-but-am-not-seeing-it-applied-yet/34999/8

### 📝 Note

<!-- レビュアーへの共有事項や画面プレビューを記載してください -->
プレビュー環境で確認できないため、マージ後に影響確認が必要です。

![image](https://github.com/user-attachments/assets/9b4c954d-e225-4a91-b8a9-e74a7dd4fa9d)
