### PR TITLE
タイムテーブルを更新

### DIFF
--- a/apps/web/app/components/time-table/TimeTableCard.vue
+++ b/apps/web/app/components/time-table/TimeTableCard.vue
@@ -61,6 +61,9 @@ const { range } = useRange()
         >
           {{ currentLocale === 'en' ? row.subTitle_en : row.subTitle }}
         </component>
+        <p v-if="row.description" class="description">
+          {{ currentLocale === 'en' ? row.description_en : row.description }}
+        </p>
       </div>
       <div
         v-for="session in row.sessions"
@@ -143,6 +146,12 @@ const { range } = useRange()
   line-height: 1.5;
   color: var(--color-vue-blue);
   text-decoration: none;
+}
+.description {
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--color-vue-blue);
 }
 ._link:hover {
   opacity: 0.6;

--- a/apps/web/app/components/time-table/TimeTableRow.vue
+++ b/apps/web/app/components/time-table/TimeTableRow.vue
@@ -52,6 +52,9 @@ const { range } = useRange()
         >
           {{ currentLocale === 'en' ? row.subTitle_en : row.subTitle }}
         </component>
+        <p v-if="row.description" class="description">
+          {{ currentLocale === 'en' ? row.description_en : row.description }}
+        </p>
       </div>
       <div
         v-for="session in row.sessions"
@@ -110,6 +113,12 @@ const { range } = useRange()
   line-height: 1.2;
   color: var(--color-vue-blue);
   text-decoration: none;
+}
+.description {
+  margin-top: 12px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--color-vue-blue);
 }
 ._link:hover {
   opacity: 0.6;

--- a/apps/web/app/utils/data/timetable_pc.json
+++ b/apps/web/app/utils/data/timetable_pc.json
@@ -29,10 +29,12 @@
         "noDisplayTime": true
       },
       {
-        "title": "サテライト",
-        "title_en": "Satellite",
+        "subTitle": "サテライト",
+        "subTitle_en": "Satellite",
+        "description": "メドピアトラックで行われるプログラムの映像と音声が同時中継されます。サテライトではキーノートは英語のみとなります。",
+        "description_en": "The video and audio of the program held at the MedPeer truck will be broadcast live. At the satellite venue, the keynote will be in English only.",
         "colspan": 1,
-        "rowspan": 1,
+        "rowspan": 5,
         "track": "mntsq"
       },
       {
@@ -58,13 +60,6 @@
         "isOpeningOrKeyNote": true,
         "isTranslation": true,
         "noDisplayTime": true
-      },
-      {
-        "title": "サテライト",
-        "title_en": "Satellite",
-        "colspan": 1,
-        "rowspan": 1,
-        "track": "mntsq"
       }
     ]
   },
@@ -76,16 +71,9 @@
         "subTitle_en": "Platinum Sponsor Session",
         "colspan": 1,
         "rowspan": 1,
-        "sessions": [],
+        "sessions": [{ "id": "74fa37c4-73ce-4657-96b9-6ea0c168f52f" }],
         "track": "medpeer",
         "isSponsor": true
-      },
-      {
-        "title": "サテライト",
-        "title_en": "Satellite",
-        "colspan": 1,
-        "rowspan": 1,
-        "track": "mntsq"
       }
     ]
   },
@@ -97,16 +85,9 @@
         "subTitle_en": "Platinum Sponsor Session",
         "colspan": 1,
         "rowspan": 1,
-        "sessions": [],
+        "sessions": [{ "id": "7c240d6f-046d-4227-9960-2a77f6b03d5a" }],
         "track": "medpeer",
         "isSponsor": true
-      },
-      {
-        "title": "サテライト",
-        "title_en": "Satellite",
-        "colspan": 1,
-        "rowspan": 1,
-        "track": "mntsq"
       }
     ]
   },
@@ -118,16 +99,9 @@
         "subTitle_en": "Platinum Sponsor Session",
         "colspan": 1,
         "rowspan": 1,
-        "sessions": [],
+        "sessions": [{ "id": "7ed3097b-a3fd-4dac-9126-903518c5cb0e" }],
         "track": "medpeer",
         "isSponsor": true
-      },
-      {
-        "title": "サテライト",
-        "title_en": "Satellite",
-        "colspan": 1,
-        "rowspan": 1,
-        "track": "mntsq"
       }
     ]
   },
@@ -150,7 +124,7 @@
         "subTitle_en": "Special Lunch Session",
         "colspan": 1,
         "rowspan": 2,
-        "sessions": [],
+        "sessions": [{ "id": "6b2f871f-e4ef-44c6-a409-9acb52843edf" }],
         "track": "medpeer"
       },
       {
@@ -166,7 +140,7 @@
         "subTitle_en": "Lunch Session",
         "colspan": 1,
         "rowspan": 2,
-        "sessions": [],
+        "sessions": [{ "id": "0546afde-7a50-4c5f-80ec-faec2eee7211" }],
         "track": "kickflow"
       }
     ]

--- a/apps/web/app/utils/data/timetable_sp.json
+++ b/apps/web/app/utils/data/timetable_sp.json
@@ -25,8 +25,10 @@
         "noDisplayTime": true
       },
       {
-        "title": "サテライト",
-        "title_en": "Satellite",
+        "subTitle": "サテライト",
+        "subTitle_en": "Satellite",
+        "description": "メドピアトラックで行われるプログラムの映像と音声が同時中継されます。サテライトではキーノートは英語のみとなります。",
+        "description_en": "The video and audio of the program held at the MedPeer truck will be broadcast live. At the satellite venue, the keynote will be in English only.",
         "track": "mntsq"
       }
     ]
@@ -42,8 +44,10 @@
         "noDisplayTime": true
       },
       {
-        "title": "サテライト",
-        "title_en": "Satellite",
+        "subTitle": "サテライト",
+        "subTitle_en": "Satellite",
+        "description": "メドピアトラックで行われるプログラムの映像と音声が同時中継されます。サテライトではキーノートは英語のみとなります。",
+        "description_en": "The video and audio of the program held at the MedPeer truck will be broadcast live. At the satellite venue, the keynote will be in English only.",
         "track": "mntsq"
       }
     ]
@@ -54,13 +58,19 @@
       {
         "subTitle": "プラチナスポンサー\nセッション",
         "subTitle_en": "Platinum Sponsor Session",
-        "sessions": [],
+        "sessions": [
+          { "id": "74fa37c4-73ce-4657-96b9-6ea0c168f52f" },
+          { "id": "7c240d6f-046d-4227-9960-2a77f6b03d5a" },
+          { "id": "7ed3097b-a3fd-4dac-9126-903518c5cb0e" }
+        ],
         "track": "medpeer",
         "isSponsor": true
       },
       {
-        "title": "サテライト",
-        "title_en": "Satellite",
+        "subTitle": "サテライト",
+        "subTitle_en": "Satellite",
+        "description": "メドピアトラックで行われるプログラムの映像と音声が同時中継されます。サテライトではキーノートは英語のみとなります。",
+        "description_en": "The video and audio of the program held at the MedPeer truck will be broadcast live. At the satellite venue, the keynote will be in English only.",
         "track": "mntsq"
       }
     ]
@@ -76,7 +86,7 @@
       {
         "subTitle": "スペシャル\nランチセッション",
         "subTitle_en": "Special Lunch Session",
-        "sessions": [],
+        "sessions": [{ "id": "6b2f871f-e4ef-44c6-a409-9acb52843edf" }],
         "track": "medpeer"
       },
       {
@@ -88,7 +98,7 @@
       {
         "subTitle": "ランチセッション",
         "subTitle_en": "Lunch Session",
-        "sessions": [],
+        "sessions": [{ "id": "0546afde-7a50-4c5f-80ec-faec2eee7211" }],
         "track": "kickflow"
       }
     ]

--- a/packages/model/lib/timeTable.ts
+++ b/packages/model/lib/timeTable.ts
@@ -12,6 +12,8 @@ export type Row = {
   title_en?: string
   subTitle?: string
   subTitle_en?: string
+  description?: string
+  description_en?: string
   colspan: number
   rowspan: number
   sessions?: Speaker[]

--- a/packages/model/lib/timetable.ts
+++ b/packages/model/lib/timetable.ts
@@ -12,6 +12,8 @@ export type Row = {
   title_en?: string
   subTitle?: string
   subTitle_en?: string
+  description?: string
+  description_en?: string
   colspan: number
   rowspan: number
   sessions?: Speaker[]


### PR DESCRIPTION
### 📚 Description
タイムテーブルを更新しました。
- プラチナスポンサーセッション
  - 全セッションを追加
- サテライト
  - セルを結合し、説明文を追加。
- ランチセッション
  - 現状きているものだけ追加（Yuhei FUJITA、渡邉龍之介）

### 📝 Note
サテライトの文言は以下を参照しています。
https://github.com/vuejs-jp/vuefes-2024-backside/issues/260#issuecomment-2376060221
