### PR TITLE
fix: ネームカードの背景画像のz-indexを修正

### DIFF
--- a/packages/ui/components/namecard/OgCard24.vue
+++ b/packages/ui/components/namecard/OgCard24.vue
@@ -82,6 +82,7 @@ onMounted(() => {
   align-items: center;
   gap: 0.875rem;
   font-size: 1.25rem;
+  z-index: 2;
   img {
     height: 100%;
   }


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/430

### 📚 Description


### 📝 Note
Windows / Chrome
![image](https://github.com/user-attachments/assets/616aa835-ab3f-4569-817a-3521f81cb0a7)

Windows / Edge
![image](https://github.com/user-attachments/assets/ebc60b8a-277c-43f4-9800-d760d987b500)

Windows / Firefox
![image](https://github.com/user-attachments/assets/d82da172-a83d-4b42-a01d-84aa624e2e23)

Mac / Safari
<img width="977" alt="image" src="https://github.com/user-attachments/assets/d68f626c-afb7-44b8-a06d-a414ff5aad24">

iPhone Xs Max / Safari
![852C652A-69A2-41F0-A9EC-90ADB19C90AB](https://github.com/user-attachments/assets/d7426655-4def-4472-b08d-fded99e4ef21)
