### PR TITLE
Fix/ Update responsive styles for tablet and mobile devices

### DIFF
--- a/apps/web/app/components/event/PanelerList.vue
+++ b/apps/web/app/components/event/PanelerList.vue
@@ -39,10 +39,12 @@ const currentLocale = useLocaleCurrent().locale
   gap: calc(var(--unit) * 2);
   padding: calc(var(--unit) * 5) calc(var(--unit) * 12) calc(var(--unit) * 5);
 
-  @media (--tablet) {
+  @media (--mobile) {
     gap: calc(var(--unit) * 1);
     padding: calc(var(--unit) * 2);
+  }
 
+  @media (--tablet) {
     ::v-deep(.speaker-name) {
       font-size: 0.875rem;
       letter-spacing: 0.4px;
@@ -58,7 +60,7 @@ const currentLocale = useLocaleCurrent().locale
   width: calc(calc(100% - 16px) / 2);
   height: 120px;
 
-  @media (--mobile) {
+  @media (--tablet) {
     width: 100%;
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/vuejs-jp/vuefes-2024-backside/issues/432

### 📚 Description
- 影響範囲を狭めて、デザイン崩れが発生しないように調整

900px
![image](https://github.com/user-attachments/assets/c613bbfb-65a1-472d-babd-2b5d43c27584)
769px
![image](https://github.com/user-attachments/assets/8e0649cc-814b-422d-99e3-88c336ae4f7a)
768px
![image](https://github.com/user-attachments/assets/5138a204-1daa-4429-b90d-0758172c1887)
481px
![image](https://github.com/user-attachments/assets/ffddd732-ad6c-4f22-803a-29fcc6eb31b1)
480px
![image](https://github.com/user-attachments/assets/2ae34150-2460-4770-be45-9d18af96eb31)

### 📝 Note
<!-- レビュアーへの共有事項や画面プレビューを記載してください -->
別の問題として769pxは他のセクションが崩れている（このissueでは対応しない）
![image](https://github.com/user-attachments/assets/fbf34740-c1b2-4c08-b828-f53556c5fcd4)
